### PR TITLE
Total count of files uploading was unreliable

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -162,7 +162,7 @@
 						
 					reader.index = i;
 					if (files[i].size > max_file_size) {
-						opts.error(errors[2], reader.file);
+						opts.error(errors[2], files[i]);
 						return false;
 					}
 					


### PR DESCRIPTION
The property e.target.len was undefined after the last largest file was done uploading and afterAll would not get called.  This only happened when a large file was uploaded with two smaller files.  I switched to a var that is set before the files start uploading.
