### PR TITLE
Fix multipart messages

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -82,13 +82,10 @@
 			builder += crlf;
 			builder += 'Content-Disposition: form-data; name="'+i+'"';
 			builder += crlf;
+			builder += crlf;
 			builder += val;
 			builder += crlf;
 		});
-		
-		builder += dashdash;
-		builder += boundary;
-		builder += crlf;
 		
 		builder += dashdash;
 		builder += boundary;


### PR DESCRIPTION
An additional blank line is required after each multipart part's header (see http://www.ietf.org/rfc/rfc1341.txt, section 7.2). This blank line is missing for the additional POST params that can be passed along in the data option.
