### PR TITLE
Running it in IE

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -66,6 +66,11 @@
 	function drop(e) {
 		opts.drop(e);
 		files = e.dataTransfer.files;
+		if (files === null || files === undefined) {
+			opts.error(errors[0]);
+			return false;
+		}
+		
 		files_count = files.length;
 		upload();
 		e.preventDefault();


### PR DESCRIPTION
When running this in IE8 I ran into some null or not an object errors.  This is a good check to have in place to catch the error right after the drop.
