### PR TITLE
$(..).filedrop('destroy') - Feature

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -324,6 +324,7 @@
 
           xhr.open("POST", opts.url, true);
           xhr.setRequestHeader('content-type', 'multipart/form-data; boundary=' + boundary);
+          xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
           // Add headers
           $.each(opts.headers, function(k, v) {


### PR DESCRIPTION
Adds a $(..).filedrop('destroy') - option to unbind all events. However only shortly tested!
