### PR TITLE
Adds the XMLHttpRequest object to the uploadFinished callback.

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -299,7 +299,7 @@
             if (xhr.responseText) {
               var now = new Date().getTime(),
                   timeDiff = now - start_time,
-                  result = opts.uploadFinished(index, file, jQuery.parseJSON(xhr.responseText), timeDiff);
+                  result = opts.uploadFinished(index, file, jQuery.parseJSON(xhr.responseText), timeDiff, xhr);
               filesDone++;
 
               // Remove from processing queue


### PR DESCRIPTION
RESTful APIs can and will use response headers quite extensively and they should be accessible in uploadFinished. In my case the API responds with a 201 Created and a link to the newly created resource in the Location-header.
