### PR TITLE
Changes decodeURI to decodeURIComponent for 'data' fields.

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -97,8 +97,8 @@
 
           $.each(params, function() {
             var pair = this.split(/=/, 2);
-            var name = decodeURI(pair[0]);
-            var val = decodeURI(pair[1]);
+            var name = decodeURIComponent(pair[0]);
+            var val = decodeURIComponent(pair[1]);
 
             builder += dashdash;
             builder += boundary;


### PR DESCRIPTION
This allows the Rails CSRF authenticity_token to be passed through to the header unscathed. Verified fix. 'decodeURI' is intended for use on a full url instead of individual components.

http://stackoverflow.com/questions/747641/what-is-the-difference-between-decodeuricomponent-and-decodeuri
