### PR TITLE
Adding error handling to jquery filedrop...

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -315,6 +315,12 @@
               }
               if (result === false) stop_loop = true;
             }
+            
+            //Pass any errors to the error option
+            if(xhr.status != 200){
+              opts.error(xhr.statusText);
+            }
+            
           };
 
         }


### PR DESCRIPTION
Found adding error handling useful in case xhr.status is not 200 (i.e. 404 or 409). I pass xhr.statusText to opts.error().
