### PR TITLE
The option callbacks need to retain the this pointer context.

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -65,8 +65,7 @@
 
   $.fn.filedrop = function(options) {
     var opts = $.extend({}, default_opts, options);
-
-    this.on('drop', drop).on('dragstart', dragStart).on('dragenter', dragEnter).on('dragover', dragOver).on('dragleave', dragLeave);
+    this.on('drop', drop).on('dragstart', opts.dragStart).on('dragenter', dragEnter).on('dragover', dragOver).on('dragleave', dragLeave);
     $(document).on('drop', docDrop).on('dragenter', docEnter).on('dragover', docOver).on('dragleave', docLeave);
 
     $('#' + opts.fallback_id).change(function(e) {
@@ -360,10 +359,6 @@
 
       function afterAll() {
         return opts.afterAll();
-      }
-
-      function dragStart(e) {
-        opts.dragStart.call(this, e);
       }
 
       function dragEnter(e) {


### PR DESCRIPTION
I noticed that when I receive an event from this library, that the `this` pointer context isn't pointing to the element the event was triggered on, but rather the filedrop object.  This is not a common pattern, which makes me think that we should consider changing it to the following...
