### PR TITLE
Add a withCredentials option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage Example
 		fallback_id: 'upload_button',   // an identifier of a standard file input element
 		url: 'upload.php',				// upload handler, handles each file separately
 		paramname: 'userfile',			// POST parameter name used on serverside to reference file
+		withCredentials: true,			// make a cross-origin request with cookies
 		data: {
 			param1: 'value1', 			// send POST variables
 			param2: function(){

--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -309,6 +309,10 @@
             newName = rename(file.name),
             mime = file.type;
 
+        if (opts.withCredentials) {
+          xhr.withCredentials = opts.withCredentials;
+        }
+
         if (typeof newName === "string") {
           builder = getBuilder(newName, e.target.result, mime, boundary);
         } else {


### PR DESCRIPTION
When making a cross-site xhr request (even to another port on the same domain), due to the security model, the browser won't send cookies unless xhr.withCredentials is set to true.

https://developer.mozilla.org/en-US/docs/HTTP_access_control

I added a setting for optionally enabling it.

Thanks for making jquery-filedrop!
