### PR TITLE
Fixed a bug in Error callback + added status code to error callbak

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -383,8 +383,8 @@
           
 
           // Pass any errors to the error option
-          if (xhr.status < 200 && xhr.status > 299) {
-            opts.error(xhr.statusText);
+          if (xhr.status < 200 || xhr.status > 299) {
+            opts.error(xhr.statusText,xhr.status);
           }
         };
       };


### PR DESCRIPTION
Hi,

I found a bug in the error callback that gets passed to the caller of the library. The original code returned an error if the http status code was less than 200 and greater than 299. 

 if (xhr.status < 200 && xhr.status > 299) {

That condition can obviously never happen. I changed it to an or (||) so that it fires the error callback if its either less than 200 or greater than 299.

 if (xhr.status < 200 || xhr.status > 299) {

I also, modified the error callback to pass both the statusText message and the status code. This will be helpful for showing more detailed error messages and will allow users to respond based on the code (404, 503 ..etc) in addition to the text description.
