### PR TITLE
Allow drop event to be canceled by returning false in callback

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -81,7 +81,7 @@
     });
 
     function drop(e) {
-      opts.drop.call(this, e);
+      if( opts.drop.call(this, e) === false ) return false;
       files = e.dataTransfer.files;
       if (files === null || files === undefined || files.length === 0) {
         opts.error(errors[0]);


### PR DESCRIPTION
This allows the user to return false in the `drop` callback to prevent the upload from starting.
