### PR TITLE
Fix error callback on HTTP != 2xx (duplicate of pull-87 but working diff)

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -52,7 +52,7 @@
       beforeEach: empty,
       afterAll: empty,
       rename: empty,
-      error: function(err, file, i) {
+      error: function(err, file, i, status) {
         alert(err);
       },
       uploadStarted: empty,
@@ -401,7 +401,7 @@
 
           // Pass any errors to the error option
           if (xhr.status < 200 || xhr.status > 299) {
-            opts.error(xhr.statusText);
+            opts.error(xhr.statusText, file, fileIndex, xhr.status);
           }
         };
       };


### PR DESCRIPTION
This is basically the same fix as https://github.com/weixiyen/jquery-filedrop/pull/87 using a fourth parameters instead of the second on the error callback. I don't mean to steal hattan's thunder, but I really would like to see this fixed :-)
