### PR TITLE
Allow URL to be either method or property

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -345,7 +345,13 @@
         upload.startData = 0;
         upload.addEventListener("progress", progress, false);
 
-        xhr.open("POST", opts.url, true);
+		// Allow url to be a method
+		if (jQuery.isFunction(opts.url)) {
+	        xhr.open("POST", opts.url(), true);
+	    } else {
+	    	xhr.open("POST", opts.url, true);
+	    }
+	    
         xhr.setRequestHeader('content-type', 'multipart/form-data; boundary=' + boundary);
 
         // Add headers


### PR DESCRIPTION
Sometimes you may want to compute the value of URL instead of having it be a property.  Simple change to allow for that.
