### PR TITLE
FIXED: Whitespaces replaced by plus signs in data

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -99,7 +99,7 @@
           builder = '';
 
       if (opts.data) {
-        var params = $.param(opts.data).replace(/\+/g, ' ').split(/&/);
+        var params = $.param(opts.data).replace(/\+/g, '%20').split(/&/);
 
         $.each(params, function() {
           var pair = this.split("=", 2),


### PR DESCRIPTION
When submitting data along with the files to upload, if the data contained whitespaces, they were encoded to plus signs. This is due to the use of jQuery.param() method, which is designed to work with data encoded as application/x-www-form-urlencoded. In this case, as we are submitting files, the enctype is multipart/form-data and whitespaces must be encoded as %20.
