### PR TITLE
Fix for empty opts.data

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -106,6 +106,10 @@
               name = decodeURIComponent(pair[0]),
               val  = decodeURIComponent(pair[1]);
 
+          if (pair.length !== 2) {
+              return;
+          }
+
           builder += dashdash;
           builder += boundary;
           builder += crlf;


### PR DESCRIPTION
Fixes cases where opt.data is an empty hash. params would contain a single blank string, causing "undefined" to show up in the post body, eg:

--------multipartformboundary1361198653141
Content-Disposition: form-data; name=""

undefined
