### PR TITLE
using FormData, paramname can be function now, filter by allowed extensions, url function has the file as parameter added

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -32,6 +32,7 @@
     jQuery.event.props.push("dataTransfer");
 
     var default_opts = {
+        timeoutLeave: 100,
         element: null,
         fallback_id: '',
         url: '',
@@ -391,6 +392,9 @@
                     // we use browsers native functionality 
                     var f = new FormData();
                     f.append(typeof(opts.paramname) === "function" ? opts.paramname() : opts.paramname, file);
+                    $.each(opts.data, function(k,v){
+                        f.append(k, v);
+                    });
                     xhr.send(f);
                 } else { 
                     // we need to simulate the browser native functionality
@@ -403,8 +407,6 @@
                     }
                     xhr.sendAsBinary(builder);
                 }
-                
-                
 
                 global_progress[global_progress_index] = 0;
                 globalProgress();
@@ -529,7 +531,7 @@
                 return function() {
                     opts.docLeave.call(_this, e);
                 };
-            })(this), 200);
+            })(this), opts.timeoutLeave);
         }
 
         return this;


### PR DESCRIPTION
Added the ability to select the native functionality of the browser for sending data. In our case the usage for window.FormData instead of building the response manually.

paramname can be both function and parameter

Added the ability to filter extensions

Url has the file object passed as a parameter when it's a function
