### PR TITLE
Forced X-Requested-With in request

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -353,6 +353,7 @@
 	    }
 	    
         xhr.setRequestHeader('content-type', 'multipart/form-data; boundary=' + boundary);
+        xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
 
         // Add headers
         $.each(opts.headers, function(k, v) {


### PR DESCRIPTION
At least in Chrome request headers does not contain X-Requested-With, therefore making request indistinguishable from non xhr one.
