### PR TITLE
ability to set a different verb, like "PUT" within options

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -34,6 +34,7 @@
       url: '',
       refresh: 1000,
       paramname: 'userfile',
+      requestType: 'POST',    // just in case you want to use another HTTP verb
       allowedfiletypes:[],
       maxfiles: 25,           // Ignored if queuefiles is set > 0
       maxfilesize: 1,         // MB file size limit
@@ -347,9 +348,9 @@
 
 		// Allow url to be a method
 		if (jQuery.isFunction(opts.url)) {
-	        xhr.open("POST", opts.url(), true);
+	        xhr.open(opts.requestType, opts.url(), true);
 	    } else {
-	    	xhr.open("POST", opts.url, true);
+	    	xhr.open(opts.requestType, opts.url, true);
 	    }
 	    
         xhr.setRequestHeader('content-type', 'multipart/form-data; boundary=' + boundary);


### PR DESCRIPTION
A current API I'm working with requires a PUT.  Within this scenario, I'm technically adding this file to an existing "asset" within the system.  The API makers consider it an update, hence the PUT of the file.

The options default to "POST" however since that will be the 99.99% case.
