### PR TITLE
Use ArrayBufferView for sending data when it's available

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -500,7 +500,15 @@
       }
       var ords = Array.prototype.map.call(datastr, byteValue);
       var ui8a = new Uint8Array(ords);
-      this.send(ui8a.buffer);
+
+      // Not pretty: Chrome 22 deprecated sending ArrayBuffer, moving instead
+      // to sending ArrayBufferView.  Sadly, no proper way to detect this
+      // functionality has been discovered.  Happily, Chrome 22 also introduced
+      // the base ArrayBufferView class, not present in Chrome 21.
+      if ('ArrayBufferView' in window)
+        this.send(ui8a);
+      else
+        this.send(ui8a.buffer);
     };
   } catch (e) {}
 


### PR DESCRIPTION
Fixes #85 and #100

Chrome 22 [deprecated using ArrayBuffer in XHR2.send](http://updates.html5rocks.com/2012/07/Arrived-xhr-send-ArrayBufferViews), introducing the more preferred `ArrayBufferView` object.  Apparently this was a change made in reaction to the [spec itself](http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-send) changing, so it's reasonable to assume than any browser that does not implement `ArrayBufferView` supports the old style, while those that do implement it support the new style.
