### PR TITLE
Option to disable 'click' firing the fallback upload element.

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -43,6 +43,7 @@
       queuewait: 200,         // Queue wait time if full
       data: {},
       headers: {},
+      fallbackClick : true,
       drop: empty,
       dragStart: empty,
       dragEnter: empty,
@@ -81,9 +82,11 @@
     this.on('drop', drop).on('dragstart', opts.dragStart).on('dragenter', dragEnter).on('dragover', dragOver).on('dragleave', dragLeave);
     $(document).on('drop', docDrop).on('dragenter', docEnter).on('dragover', docOver).on('dragleave', docLeave);
 
-    this.on('click', function(e){
-      $('#' + opts.fallback_id).trigger(e);
-    });
+    if(opts.fallbackClick){
+      this.on('click', function(e){
+        $('#' + opts.fallback_id).trigger(e);
+      });      
+    }
 
     $('#' + opts.fallback_id).change(function(e) {
       opts.drop(e);


### PR DESCRIPTION
Just added the simple boolean option (fallbackClick) that can disable/enable triggering the fallback upload dialog when clicking the element that the filedrop script is attached to.
