### PR TITLE
Avoid "Maximum call stack size exceeded"

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -81,10 +81,6 @@
     this.on('drop', drop).on('dragstart', opts.dragStart).on('dragenter', dragEnter).on('dragover', dragOver).on('dragleave', dragLeave);
     $(document).on('drop', docDrop).on('dragenter', docEnter).on('dragover', docOver).on('dragleave', docLeave);
 
-    this.on('click', function(e){
-      $('#' + opts.fallback_id).trigger(e);
-    });
-
     $('#' + opts.fallback_id).change(function(e) {
       opts.drop(e);
       files = e.target.files;


### PR DESCRIPTION
Fix the click method to choose files and avoid the javascript error
«Maximum call stack size exceeded»
